### PR TITLE
feat(docker): init docker images workflow

### DIFF
--- a/.github/dgoss_validate.yaml
+++ b/.github/dgoss_validate.yaml
@@ -1,0 +1,23 @@
+---
+group:
+  alumet:
+    exists: true
+user:
+  alumet:
+    exists: true
+file:
+  /etc/alumet/alumet-config.toml:
+    exists: true
+    owner: alumet
+    group: alumet
+    mode: "0644"
+  /usr/bin/alumet-agent:
+    exists: true
+    owner: alumet
+    group: alumet
+    mode: "0555"
+
+command:
+  'run alumet-agent':
+    exec: "/usr/bin/alumet-agent --config /etc/alumet/alumet-config.toml --plugins csv,perf,procfs,socket-control exec -- sleep 1 && [ -s alumet-output.csv ]"
+    exit-status: 0

--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -1,0 +1,137 @@
+---
+name: Build Docker images pipeline
+on:
+  workflow_call:
+    inputs:
+      target-architecture:
+        description: 'What is the architecture we want to build for'
+        required: true
+        type: string
+      build-version:
+        description: 'What is the version used to build and tag the RPMs'
+        required: true
+        type: string
+      release-version:
+        description: 'What is the release version used to build and tag the RPMs'
+        required: true
+        type: string
+
+jobs:
+  packaging:
+    name: packaging (${{ matrix.os.name }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      ARCH: ${{ (inputs.target-architecture == 'x86_64' && matrix.os.type == 'deb') && 'amd64' || inputs.target-architecture }}
+      OUTPUT_ARTIFACT_NAME: alumet-agent-${{ inputs.build-version }}-${{ inputs.release-version }}.${{ matrix.os.name }}.${{ inputs.target-architecture }}.docker.tar
+    strategy:
+      matrix:
+        os:
+          - { name: ubi9.5,       type: rpm, path: "docker/ubi",     base-image: registry.access.redhat.com/ubi9-micro:9.5,  builder-image: registry.access.redhat.com/ubi9:9.5,  libssl-version: 3,   libcrypto-version: 3, latest_tag: true}
+          - { name: ubi8.3,       type: rpm, path: "docker/ubi",     base-image: registry.access.redhat.com/ubi8-micro:8.10, builder-image: registry.access.redhat.com/ubi8:8.10, libssl-version: 1.1, libcrypto-version: 1.1 }
+          - { name: fc42,         type: rpm, path: "docker/fedora",  base-image: fedora:42 }
+          - { name: debian_12,    type: deb, path: "docker/debian" , base-image: debian:12-slim }
+          - { name: ubuntu_25.04, type: deb, path: "docker/ubuntu",  base-image: ubuntu:25.04 }
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        repository: alumet-dev/packaging
+
+      - name: Define the dependency artifact name (RPM)
+        if: matrix.os.type == 'rpm'
+        run: echo "DEPS_ARTIFACT_FILE=alumet-agent-${{ inputs.build-version }}-${{ inputs.release-version }}.${{ matrix.os.name }}.${{ env.ARCH }}.rpm" >> $GITHUB_ENV
+
+      - name: Define the dependency artifact name (DEB)
+        if: matrix.os.type == 'deb'
+        run: echo "DEPS_ARTIFACT_FILE=alumet-agent_${{ inputs.build-version }}-${{ inputs.release-version }}_${{ env.ARCH }}_${{ matrix.os.name }}.deb" >> $GITHUB_ENV
+
+      - name: Create the dependency artifacts directory
+        run: mkdir -p build/deps-artifacts
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.DEPS_ARTIFACT_FILE }}
+          path: ${{ matrix.os.path }}
+
+      - name: Create docker image output dir
+        run: mkdir -p build/docker
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up image tags
+        run: |
+          TAGS="ghcr.io/${{ github.repository_owner }}/alumet-agent:${{ inputs.build-version }}-${{ inputs.release-version }}_${{ matrix.os.name }}"
+          if [ "${{ matrix.os.latest_tag }}" == "true" ]; then
+            TAGS="$TAGS,ghcr.io/${{ github.repository_owner }}/alumet-agent:latest"
+          fi
+          echo "TAGS=$TAGS" >> $GITHUB_ENV
+          echo "Images tags: $TAGS" >> $GITHUB_STEP_SUMMARY
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.os.path }}
+          push: false
+          file: ${{ matrix.os.path }}/Dockerfile
+          build-args: |
+            ALUMET_VERSION=${{ inputs.build-version }}
+            BUILDER_IMAGE=${{ matrix.os.builder-image }}
+            BASE_IMAGE=${{ matrix.os.base-image }}
+            ARTIFACT_FILE=${{ env.DEPS_ARTIFACT_FILE }}
+            LIBSSL_VERSION=${{ matrix.os.libssl-version }}
+            LIBCRYPTO_VERSION=${{ matrix.os.libcrypto-version }}
+          outputs: type=docker,dest=build/docker/${{ env.OUTPUT_ARTIFACT_NAME }}
+          tags: ${{ env.TAGS }}
+        env:
+          DOCKER_BUILD_SUMMARY: false
+
+      - name: Upload docker image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.OUTPUT_ARTIFACT_NAME }}
+          path: ./build/docker/${{ env.OUTPUT_ARTIFACT_NAME }}
+
+  testing:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      DOCKER_ARTIFACT_NAME: alumet-agent-${{ inputs.build-version }}-${{ inputs.release-version }}.${{ matrix.os }}.${{ inputs.target-architecture }}.docker.tar
+    strategy:
+      matrix:
+        os: ["ubi9.5", "ubi8.3", "fc42", "debian_12", "ubuntu_25.04"]
+    needs:
+      - packaging
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        repository: alumet-dev/packaging
+
+      - name: Create docker artifacts directory
+        run: mkdir docker-artifacts
+
+      - name: Download docker images artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.DOCKER_ARTIFACT_NAME }}
+          path: ./docker-artifacts
+      
+      - name: Install Goss / Dgoss
+        run: |
+          curl -fsSL https://goss.rocks/install | sh
+
+      - name: Run Dgoss tests
+        run: |
+          image_sha=$(docker load -q -i ./docker-artifacts/${{ env.DOCKER_ARTIFACT_NAME }} | grep "Loaded image: "| awk '{ print $3 }' | head -1)
+          export GOSS_FILE=.github/dgoss_validate.yaml
+          set -o pipefail
+          dgoss run --cap-add=perfmon --cap-add=sys_nice $image_sha 2>&1 | tee ${{ matrix.os }}-dgoss_tests_report.txt >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload tests reports
+        if: always() # never skip to have file even in case of test failure
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os }}-dgoss_tests_report.txt
+          path: ${{ matrix.os }}-dgoss_tests_report.txt

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,42 @@
+# Run docker container
+
+## Using RAPL plugin
+
+The RAPL plugin reads system files and need some specific permissions:
+
+### Perfmon usage
+
+You will need to set the kernel parameter perf_event_paranoid to 0:
+Run `sudo sysctl -w kernel.perf_event_paranoid=0` in host before starting the Alumet container.
+Note that this command make this parameter temporary and it will be reset after reboot.
+If you want to make it persistent check the code of sysctl.
+
+While running the container, you also need to add some capabilities, you can do it through `--cap-add=perfmon --cap-add=sys_nice` flags.
+
+### /sys/devices/virtual/powercap/intel-rapl
+
+In RAPL plugin `/sys/devices/virtual/powercap/intel-rapl` can mounted for two different use cases.
+It's not mandatory unless you want to use powercap instead of perfmon. Here are more details:
+
+#### 1/ Powercap usage
+In case **perfmon** is disable the plugin will try to use **powercap** and need that dir mounted.
+In this case you may need to use **root** user and add capabilities (see --cap-add above) to be able to make powercap works properly.
+
+#### 2/ Consistency check
+The RAPL plugin has a **consistency** check that help detect bad behaviors between perf_event and powercap on domain detection.
+This check help user by printing warnings in case there are different domains detected by perf_event and powercap. **It's purely informative and doesn't impact measurement** .
+For this check to work you need /sys/devices/virtual/powercap/intel-rapl to be mounted, which is masked by default by docker container.
+
+You can overpass it by passing `--security-opt="systempaths=unconfined"` or by using `--privileged` flag (not recommended) or using **root** user (not recommended as well).
+
+In case you're using **podman**, you can also use `--security-opt unmask=/sys/devices/virtual/powercap/intel-rapl` which will only unmask this interface.
+
+Here are the kind of errors logged when consistency check try to start:
+```
+[2025-03-13T14:09:02Z ERROR plugin_rapl] Cannot read the list of RAPL domains available via the powercap interface: Could not explore /sys/devices/virtual/powercap/intel-rapl. Try to adjust file permissions.
+
+    Caused by:
+        No such file or directory (os error 2).
+[2025-03-13T14:09:02Z WARN  plugin_rapl] The consistency of the RAPL domains reported by the different interfaces of the Linux kernel cannot be checked (this is useful to work around bugs in some kernel versions on some machines).
+```
+It doesn't block the execution of RAPL plugin.

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -1,0 +1,30 @@
+ARG BASE_IMAGE=debian:12-slim
+FROM $BASE_IMAGE AS runtime
+
+ARG ALUMET_VERSION=0.8
+LABEL org.opencontainers.image.authors="maintainers@alumet.dev" \
+	org.opencontainers.image.documentation="https://alumet-dev.github.io/user-book" \
+	org.opencontainers.image.source="https://github.com/alumet-dev/alumet" \
+	org.opencontainers.image.version="$ALUMET_VERSION" \
+	org.opencontainers.image.vendor="alumet-dev" \
+	org.opencontainers.image.licenses="EUPL-1.2" \
+	org.opencontainers.image.title="alumet-agent based on Debian OS" \
+	org.opencontainers.image.description="Alumet is a modular tool that measures energy consumption and performance metrics. "
+
+ARG ARTIFACT_FILE=alumet_0.8-1_amd64_debian_12.deb
+COPY $ARTIFACT_FILE /tmp/
+
+RUN apt update -y && \
+    apt install -y /tmp/$ARTIFACT_FILE && \
+    rm -f /tmp/$ARTIFACT_FILE && \
+    rm /usr/bin/alumet-agent && mv /usr/lib/alumet-agent /usr/bin/alumet-agent && \
+    groupadd -r alumet && \
+    useradd -r -g alumet alumet && \
+    mkdir /app && \
+    chown alumet:alumet /usr/bin/alumet-agent /etc/alumet/alumet-config.toml /app
+
+USER alumet
+WORKDIR /app
+
+ENTRYPOINT ["/usr/bin/alumet-agent"]
+CMD ["--config", "/etc/alumet/alumet-config.toml", "--plugins", "csv,perf,procfs,socket-control", "--output-file", "/app/alumet-output.csv"]

--- a/docker/fedora/Dockerfile
+++ b/docker/fedora/Dockerfile
@@ -1,0 +1,32 @@
+ARG BASE_IMAGE=fedora:42
+FROM $BASE_IMAGE AS runtime
+
+ARG ALUMET_VERSION=0.8
+LABEL org.opencontainers.image.authors="maintainers@alumet.dev" \
+	org.opencontainers.image.documentation="https://alumet-dev.github.io/user-book" \
+	org.opencontainers.image.source="https://github.com/alumet-dev/alumet" \
+	org.opencontainers.image.version="$ALUMET_VERSION" \
+	org.opencontainers.image.vendor="alumet-dev" \
+	org.opencontainers.image.licenses="EUPL-1.2" \
+	org.opencontainers.image.title="alumet-agent based on Fedora OS" \
+	org.opencontainers.image.description="Alumet is a modular tool that measures energy consumption and performance metrics. "
+
+ARG ARTIFACT_FILE=alumet-agent-0.8.0-1.fedora.42.x86_64.rpm
+COPY $ARTIFACT_FILE /tmp/
+
+RUN dnf install -y /tmp/$ARTIFACT_FILE && \
+    rm -f /tmp/$ARTIFACT_FILE && \
+    rm /usr/bin/alumet-agent && \
+    mv /usr/lib/alumet-agent /usr/bin/alumet-agent && \
+    dnf install -y util-linux && \
+    dnf clean all && \
+    groupadd -r alumet && \
+    useradd -r -g alumet alumet && \
+    mkdir /app && \
+    chown alumet:alumet /usr/bin/alumet-agent /etc/alumet/alumet-config.toml /app
+
+USER alumet
+WORKDIR /app
+
+ENTRYPOINT ["/usr/bin/alumet-agent"]
+CMD ["--config", "/etc/alumet/alumet-config.toml", "--plugins", "csv,perf,procfs,socket-control", "--output-file", "/app/alumet-output.csv"]

--- a/docker/fedora/Dockerfile
+++ b/docker/fedora/Dockerfile
@@ -11,7 +11,7 @@ LABEL org.opencontainers.image.authors="maintainers@alumet.dev" \
 	org.opencontainers.image.title="alumet-agent based on Fedora OS" \
 	org.opencontainers.image.description="Alumet is a modular tool that measures energy consumption and performance metrics. "
 
-ARG ARTIFACT_FILE=alumet-agent-0.8.0-1.fedora.42.x86_64.rpm
+ARG ARTIFACT_FILE=alumet-agent-0.8.0-1.fc42.x86_64.rpm
 COPY $ARTIFACT_FILE /tmp/
 
 RUN dnf install -y /tmp/$ARTIFACT_FILE && \

--- a/docker/ubi/Dockerfile
+++ b/docker/ubi/Dockerfile
@@ -1,0 +1,40 @@
+ARG BUILDER_IMAGE=registry.access.redhat.com/ubi9:9.5
+ARG BASE_IMAGE=registry.access.redhat.com/ubi9-micro:9.5
+FROM $BUILDER_IMAGE AS builder
+
+ARG ALUMET_VERSION=0.8
+LABEL org.opencontainers.image.authors="maintainers@alumet.dev" \
+	org.opencontainers.image.documentation="https://alumet-dev.github.io/user-book" \
+	org.opencontainers.image.source="https://github.com/alumet-dev/alumet" \
+	org.opencontainers.image.version="$ALUMET_VERSION" \
+	org.opencontainers.image.vendor="alumet-dev" \
+	org.opencontainers.image.licenses="EUPL-1.2" \
+	org.opencontainers.image.title="alumet-agent based on Redhat UBI OS" \
+	org.opencontainers.image.description="Alumet is a modular tool that measures energy consumption and performance metrics. "
+
+ARG ARTIFACT_FILE=alumet-agent-0.8.0-1.ubi.9.5.x86_64.rpm
+COPY ${ARTIFACT_FILE} /tmp/
+
+RUN dnf install -y /tmp/$ARTIFACT_FILE && rm -f /tmp/$ARTIFACT_FILE
+
+FROM $BASE_IMAGE AS runtime
+
+ARG LIBSSL_VERSION=3
+ARG LIBCRYPTO_VERSION=3
+ARG LIBZ_VERSION=1
+COPY --from=builder /usr/lib/alumet-agent /usr/bin/alumet-agent
+COPY --from=builder /etc/alumet/alumet-config.toml /etc/alumet/alumet-config.toml
+COPY --from=builder /lib64/libssl.so.${LIBSSL_VERSION} /lib64/
+COPY --from=builder /lib64/libcrypto.so.${LIBCRYPTO_VERSION} /lib64/
+COPY --from=builder /lib64/libz.so.${LIBZ_VERSION} /lib64/
+
+RUN echo "alumet:x:1000:" >> /etc/group && \
+    echo "alumet:x:1000:1000::/home/alumet:/sbin/nologin" >> /etc/passwd && \
+	mkdir -p /app /home/alumet && \
+	chown alumet:alumet /usr/bin/alumet-agent /etc/alumet/alumet-config.toml /app # chown makes alumet-agent bin to be duplicated by docker which increase image size
+
+USER alumet
+WORKDIR /app
+
+ENTRYPOINT ["/usr/bin/alumet-agent"]
+CMD ["--config", "/etc/alumet/alumet-config.toml", "--plugins", "csv,perf,procfs,socket-control", "--output-file", "/app/alumet-output.csv"]

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -1,0 +1,30 @@
+ARG BASE_IMAGE=ubuntu:25.04
+FROM $BASE_IMAGE AS runtime
+
+ARG ALUMET_VERSION=0.8
+LABEL org.opencontainers.image.authors="maintainers@alumet.dev" \
+	org.opencontainers.image.documentation="https://alumet-dev.github.io/user-book" \
+	org.opencontainers.image.source="https://github.com/alumet-dev/alumet" \
+	org.opencontainers.image.version="$ALUMET_VERSION" \
+	org.opencontainers.image.vendor="alumet-dev" \
+	org.opencontainers.image.licenses="EUPL-1.2" \
+	org.opencontainers.image.title="alumet-agent based on Ubuntu OS" \
+	org.opencontainers.image.description="Alumet is a modular tool that measures energy consumption and performance metrics. "
+
+ARG ARTIFACT_FILE=alumet_0.8-1_amd64_ubuntu_25.04.deb
+COPY $ARTIFACT_FILE /tmp/
+
+RUN apt update -y && \ 
+    apt install -y /tmp/$ARTIFACT_FILE && \
+    rm -f /tmp/$ARTIFACT_FILE && \
+    rm /usr/bin/alumet-agent && mv /usr/lib/alumet-agent /usr/bin/alumet-agent && \
+    groupadd -r alumet && \
+    useradd -r -g alumet alumet && \
+    mkdir /app && \
+    chown alumet:alumet /usr/bin/alumet-agent /etc/alumet/alumet-config.toml /app
+
+USER alumet
+WORKDIR /app
+
+ENTRYPOINT ["/usr/bin/alumet-agent"]
+CMD ["--config", "/etc/alumet/alumet-config.toml", "--plugins", "csv,perf,procfs,socket-control", "--output-file", "/app/alumet-output.csv"]


### PR DESCRIPTION
Adding github workflow to build docker images.
This PR covers 5 docker images:

- Fedora 42
- Redhat UBI 8.3
- Redhat UBI 9.5
- Debian 12
- Ubuntu 25.04

**Redhat UBI's** images have been optimized to have minimum size (69MB that could maybe be optimized to 49MB with tricks) and sounds as good production images. The 9.5 version is also tagged as the **latest** image in the registry.
**Others** are > 100 MB and comes with package manager which make them more convenient for debug purpose.

The PR doesn't cover ARCH and only cover x86_64 (amd64) even if it gets an input variable "target-architecture". This will come in another PR later.

A job of tests is also added in the workflow and use dgoss (goss for docker) and use same validation YAML values as RPM and Debian workflows without package and systemd unit concerns.

The **docker** repository comes with a README.md file that aims to help user to use docker image with RAPL plugin and could be extended for other use cases specific to docker images.