### PR TITLE
ci(goss): Modify way to install goss and dgoss

### DIFF
--- a/.github/workflows/build_deb.yaml
+++ b/.github/workflows/build_deb.yaml
@@ -32,6 +32,7 @@ on:
 
 env:
   ACT: false
+  GOSS_VERSION: v0.4.9
 
 jobs:
   setup:
@@ -216,8 +217,13 @@ jobs:
           DEBIAN_FRONTEND=noninteractive apt-get install -y "$deb_file"
 
       - name: Install Goss
+        env:
+          ARCH: ${{ inputs.arch == 'x86_64' && 'amd64' || inputs.arch == 'aarch64' && 'arm64'}}
         run: |
-          curl -fsSL https://goss.rocks/install | sh
+          curl -L "https://github.com/goss-org/goss/releases/download/${GOSS_VERSION}/goss-linux-${{ env.ARCH }}" -o /usr/local/bin/goss
+          chmod +rx /usr/local/bin/goss
+
+          echo "/usr/local/bin" >> "$GITHUB_PATH"
 
       - name: Run Goss tests
         id: goss-tests

--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -26,6 +26,9 @@ on:
         required: false
         default: true
 
+env:
+  GOSS_VERSION: v0.4.9
+
 jobs:
 
   setup:
@@ -209,9 +212,17 @@ jobs:
           name: ${{ needs.packaging.outputs.artifact_name }}
           path: ./docker-artifacts
       
-      - name: Install Goss / Dgoss
+      - name: Install Dgoss
+        env:
+          ARCH: ${{ inputs.arch == 'x86_64' && 'amd64' || inputs.arch == 'aarch64' && 'arm64'}}
         run: |
-          curl -fsSL https://goss.rocks/install | sh
+          curl -L "https://github.com/goss-org/goss/releases/download/${GOSS_VERSION}/goss-linux-${{ env.ARCH }}" -o /usr/local/bin/goss
+          chmod +rx /usr/local/bin/goss
+
+          curl -L "https://github.com/goss-org/goss/releases/download/${GOSS_VERSION}/dgoss" -o /usr/local/bin/dgoss
+          chmod +rx /usr/local/bin/dgoss
+
+          echo "/usr/local/bin" >> "$GITHUB_PATH"
 
       - name: Run Dgoss tests
         run: |

--- a/.github/workflows/build_rpm.yaml
+++ b/.github/workflows/build_rpm.yaml
@@ -31,6 +31,7 @@ on:
 
 env:
   ACT: false
+  GOSS_VERSION: v0.4.9
 
 jobs:
   setup:
@@ -195,8 +196,13 @@ jobs:
           dnf install -y ${{ steps.download_rpm.outputs.download-path }}/*.rpm
 
       - name: Install Goss
+        env:
+          ARCH: ${{ inputs.arch == 'x86_64' && 'amd64' || inputs.arch == 'aarch64' && 'arm64'}}
         run: |
-          curl -fsSL https://goss.rocks/install | sh
+          curl -L "https://github.com/goss-org/goss/releases/download/${GOSS_VERSION}/goss-linux-${{ env.ARCH }}" -o /usr/local/bin/goss
+          chmod +rx /usr/local/bin/goss
+
+          echo "/usr/local/bin" >> "$GITHUB_PATH"
 
       - name: Run Goss tests
         id: goss-tests


### PR DESCRIPTION
Do not use anymore ```curl | sh``` as it is not recommended for production systems. 