### PR TITLE
ci(build_docker): sanitize version name used by docker

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -115,21 +115,22 @@ jobs:
       # See deb and rpm steps.
       - name: Normalize version number
         run: |
-          PKG_VERSION=$(echo ${{ inputs.version }} | sed 's/[_-]/~/g')
-          echo "PKG_VERSION=$PKG_VERSION" >> "$GITHUB_ENV"
-          echo "PKG_VERSION=$PKG_VERSION"
+          # Allowed characteres for image tag are: [a-zA-Z0-9_.-]
+          SANITIZED_VERSION=$(echo ${{ inputs.version }} | sed 's/[\^\+_]/-/g')
+          echo "SANITIZED_VERSION=$SANITIZED_VERSION" >> "$GITHUB_ENV"
+          echo "SANITIZED_VERSION=$SANITIZED_VERSION"
 
       - name: Checkout the repository
         uses: actions/checkout@v7
         with:
           repository: alumet-dev/packaging
 
-      - name: Define the dependency artifact name (RPM)
+      - name: Define the dependency artifact pattern
         run: |
           if [[ ${{ matrix.os.type }} == 'rpm' ]]; then
-            echo "DEPS_ARTIFACT_FILE=alumet-agent-${{ env.PKG_VERSION }}-${{ inputs.release-version }}.${{ matrix.os.name }}.${{ env.ARCH }}.rpm" >> "$GITHUB_ENV"
+            echo "DEPS_ARTIFACT_PATTERN=alumet-agent-*-${{ inputs.release-version }}.${{ matrix.os.name }}.${{ env.ARCH }}.rpm" >> "$GITHUB_ENV"
           else
-            echo "DEPS_ARTIFACT_FILE=alumet-agent_${{ env.PKG_VERSION }}-${{ inputs.release-version }}_${{ env.ARCH }}_${{ matrix.os.name }}.deb" >> "$GITHUB_ENV"
+            echo "DEPS_ARTIFACT_PATTERN=alumet-agent_*-${{ inputs.release-version }}_${{ env.ARCH }}_${{ matrix.os.name }}.deb" >> "$GITHUB_ENV"
           fi
 
       - name: Define the output artifact name
@@ -141,10 +142,15 @@ jobs:
         run: mkdir -p build/deps-artifacts
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
-          name: ${{ env.DEPS_ARTIFACT_FILE }}
+          pattern: ${{ env.DEPS_ARTIFACT_PATTERN }}
           path: ${{ matrix.os.path }}
+
+      - name: Locate downloaded file
+        run: |
+          FILE=$(find "${{ matrix.os.path }}" -maxdepth 1 -type f \( -name '*.rpm' -o -name '*.deb' \) | head -n1)
+          echo "DEPS_ARTIFACT_FILE=$(basename "$FILE")" >> "$GITHUB_ENV"
 
       - name: Create docker image output dir
         run: mkdir -p build/docker
@@ -157,7 +163,7 @@ jobs:
 
       - name: Set up image tags
         run: |
-          TAGS="ghcr.io/${{ github.repository_owner }}/alumet-agent:${{ inputs.version }}-${{ inputs.release-version }}_${{ matrix.os.name }}_${{ inputs.arch }}"
+          TAGS="ghcr.io/${{ github.repository_owner }}/alumet-agent:${{ env.SANITIZED_VERSION }}-${{ inputs.release-version }}_${{ matrix.os.name }}_${{ inputs.arch }}"
           if [ "${{ matrix.os.latest_tag }}" == "true" ]; then
             TAGS="$TAGS,ghcr.io/${{ github.repository_owner }}/alumet-agent:latest_${{ inputs.arch }}"
           fi


### PR DESCRIPTION
When creating a snapshot, some artifacts may contain symbols that are not supported by Docker in image tags.